### PR TITLE
Fix dungeon warp cooldown regex

### DIFF
--- a/features/DungeonCooldownTimer.js
+++ b/features/DungeonCooldownTimer.js
@@ -11,7 +11,7 @@ const getSecondsLeft = () => (30 - (Date.now() - data.dungeonWarpCooldown.lastWa
 register("chat", () => {
     data.dungeonWarpCooldown.lastWarp = Date.now()
     data.save()
-}).setCriteria(/^-*>newLine<-(?:\[[^\]]+\] )(\w+) entered \w+ Catacombs, Floor (\w+)!->newLine<-*$/)
+}).setCriteria(/^-*>newLine<-(?:\[[^\]]+\] )(\w+) entered M?M? ?The Catacombs, Floor (\w+)!->newLine<-*$/)
 
 registerWhen(register("renderOverlay", () => {
     if (!Config.dungeonCooldown || !data.dungeonWarpCooldown.lastWarp) return


### PR DESCRIPTION
Not sure how optimal the regex is as I am not very familiar but this works for all floors and MM